### PR TITLE
Update trivial label check

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -23,7 +23,7 @@ end
 # Is this declared a trivial change?
 # ------------------------------------------------------------------------------
 def declared_trivial?
-  !(github.pr_labels.include? 'trivial')
+  github.pr_labels.include?('trivial')
 end
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
An error is not being thrown if a `CHANGELOG.md` is missing when required because all PRs are being seen as marked as `trivial`.