### PR TITLE
Update modified program sets

### DIFF
--- a/incent-config/Dangerfile
+++ b/incent-config/Dangerfile
@@ -24,6 +24,7 @@ def modified_program_sets
   @modified_program_sets ||= git.modified_files
     .concat(git.added_files)
     .map { |file| file.split('/')[0] }
+    .reject { |file| ignore_list.include?(file) }
     .uniq
 end
 


### PR DESCRIPTION
When updating `modified_program_sets`, the `ignore_list` was not provided. So files modified or added in a directory such as `bin` would get erroneously included in the list of program-sets.