### PR TITLE
chore: Clean-up dangerfiles and add AB# check

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -74,11 +74,6 @@ end
 warn('PR is classed as Work in Progress') if declared_wip?
 
 # ------------------------------------------------------------------------------
-# Warn when there is a big PR
-# ------------------------------------------------------------------------------
-warn('Big PR') if git.lines_of_code > 500
-
-# ------------------------------------------------------------------------------
 # Thank contributors
 # ------------------------------------------------------------------------------
 message(':tada:') if version_bump? && github.pr_author != 'johnallen3d'
@@ -137,4 +132,11 @@ end
 # ------------------------------------------------------------------------------
 def base_branch_master?
   @base_branch_master ||= github.branch_for_base.eql?('master')
+end
+
+# ------------------------------------------------------------------------------
+# Does PR body include ADO ticket number?
+# ------------------------------------------------------------------------------
+def pr_has_ticket_number?
+  github.pr_body.include?('AB#')
 end

--- a/gems/Dangerfile
+++ b/gems/Dangerfile
@@ -6,12 +6,11 @@ danger.import_dangerfile(
 fail('Please add a description for your PR') if github.pr_body.empty?
 
 # ------------------------------------------------------------------------------
-# Requre a CHANGELOG entry for library changes
+# Fail when PR body does not have ADO ticket number
 # ------------------------------------------------------------------------------
-if !changelog_modified? && app_changes? && !declared_trivial?
-  changelog_message = <<-MESSAGE
-    Please include a CHANGELOG entry. You can find it at ./CHANGELOG.md
-  MESSAGE
+fail('PR has no ADO ticket number') if !pr_has_ticket_number? && !release_branch?
 
-  fail(strip_doc(changelog_message))
-end
+# ------------------------------------------------------------------------------
+# Warn when there is a big PR
+# ------------------------------------------------------------------------------
+warn('Big PR') if git.lines_of_code > 500

--- a/incent-config/Dangerfile
+++ b/incent-config/Dangerfile
@@ -44,7 +44,7 @@ def program_set_from_pr_title
   return 'na' if not_applicable_pr_title?
 
   @program_set_from_pr_title ||=
-    directories.find { |dir| github.pr_title.include?("[#{dir}]") }.to_s
+    directories.find { |dir| github.pr_title.include?("[#{dir}]") || github.pr_title.include?("(#{dir})") }.to_s
 end
 
 def program_set_from_branch
@@ -54,10 +54,10 @@ def program_set_from_branch
 end
 
 def program_set_from_commit
-  return 'na' if commit_subject.include?('[na]') || commit_body.include?('[na]')
+  return 'na' if not_applicable_subject? || not_applicable_body?
 
   @program_set_from_commit ||= directories.find do |dir|
-    commit_subject.include?("[#{dir}]") || commit_body.include?("[#{dir}]")
+    commit_subject.include?("[#{dir}]") || commit_body.include?("[#{dir}]") || commit_subject.include?("(#{dir})") || commit_body.include?("(#{dir})")
   end
 end
 
@@ -89,7 +89,7 @@ def commit_body
 end
 
 def not_applicable_pr_title?
-  github.pr_title.start_with?('[na]')
+  github.pr_title.start_with?('[na]') || github.pr_title.include?('(na)')
 end
 
 def not_applicable_branch_name?
@@ -97,11 +97,11 @@ def not_applicable_branch_name?
 end
 
 def not_applicable_subject?
-  commit_subject.include?('[na]')
+  commit_subject.include?('[na]') || commit_subject.include?('(na)')
 end
 
 def not_applicable_body?
-  commit_body.include?('[na]')
+  commit_body.include?('[na]') || commit_body.include?('(na)')
 end
 
 def valid_commit_message?
@@ -195,3 +195,8 @@ fail('Please only modify one program-set at a time') if multiple_program_sets?
 fail('Please do not add Rakefiles to config repos') if rakefile_added?
 
 fail('Please add a description for your PR') if github.pr_body.empty?
+
+# ------------------------------------------------------------------------------
+# Fail when PR body does not have ADO ticket number
+# ------------------------------------------------------------------------------
+fail('PR has no ADO ticket number') if !pr_has_ticket_number?

--- a/incent-config/Dangerfile
+++ b/incent-config/Dangerfile
@@ -91,8 +91,12 @@ def commit_body
   @commit_body ||= `git log --pretty=format:%b --reverse -1`
 end
 
+def not_applicable?(text)
+  ["[na]", "(na)"].any? { |na| text.include?(na) }
+end
+
 def not_applicable_pr_title?
-  ["[na]", "(na)"].any? { |na| pr_title.include?(na) }
+  not_applicable?(pr_title)
 end
 
 def not_applicable_branch_name?
@@ -100,11 +104,11 @@ def not_applicable_branch_name?
 end
 
 def not_applicable_subject?
-  ["[na]", "(na)"].any? { |na| commit_subject.include?(na) }
+  not_applicable?(commit_subject)
 end
 
 def not_applicable_body?
-  ["[na]", "(na)"].any? { |na| commit_body.include?(na) }
+  not_applicable?(commit_body)
 end
 
 def valid_commit_message?

--- a/incent-config/Dangerfile
+++ b/incent-config/Dangerfile
@@ -57,7 +57,10 @@ def program_set_from_commit
   return 'na' if not_applicable_subject? || not_applicable_body?
 
   @program_set_from_commit ||= directories.find do |dir|
-    commit_subject.include?("[#{dir}]") || commit_body.include?("[#{dir}]") || commit_subject.include?("(#{dir})") || commit_body.include?("(#{dir})")
+    commit_subject.include?("[#{dir}]") ||
+      commit_body.include?("[#{dir}]") ||
+      commit_subject.include?("(#{dir})") ||
+      commit_body.include?("(#{dir})")
   end
 end
 
@@ -97,11 +100,11 @@ def not_applicable_branch_name?
 end
 
 def not_applicable_subject?
-  commit_subject.include?('[na]') || commit_subject.include?('(na)')
+  ["[na]", "(na)"].any? { |na| commit_subject.include?(na) }
 end
 
 def not_applicable_body?
-  commit_body.include?('[na]') || commit_body.include?('(na)')
+  ["[na]", "(na)"].any? { |na| commit_body.include?(na) }
 end
 
 def valid_commit_message?

--- a/incent-config/Dangerfile
+++ b/incent-config/Dangerfile
@@ -92,7 +92,7 @@ def commit_body
 end
 
 def not_applicable_pr_title?
-  github.pr_title.start_with?('[na]') || github.pr_title.include?('(na)')
+  ["[na]", "(na)"].any? { |na| pr_title.include?(na) }
 end
 
 def not_applicable_branch_name?

--- a/incent-config/Dangerfile
+++ b/incent-config/Dangerfile
@@ -96,19 +96,19 @@ def not_applicable?(text)
 end
 
 def not_applicable_pr_title?
-  not_applicable?(pr_title)
+  @not_applicable_pr_title ||= not_applicable?(pr_title)
 end
 
 def not_applicable_branch_name?
-  branch_name.include?('/na/')
+  @not_applicable_branch_name ||= branch_name.include?('/na/')
 end
 
 def not_applicable_subject?
-  not_applicable?(commit_subject)
+  @not_applicable_subject ||= not_applicable?(commit_subject)
 end
 
 def not_applicable_body?
-  not_applicable?(commit_body)
+  @not_applicable_body ||= not_applicable?(commit_body)
 end
 
 def valid_commit_message?


### PR DESCRIPTION
Fixes: AB#30629

- Remove `Big-PR` checks and move changelog check to `incent-api` and `incent-config-gem`, to be removed when `release-please` is implemented.
- Add check if `AB#` is present in PR body for feature branches (in gems).
- Make` incent-config ` danger checks flexible to allow for conventional commits; `type:(incent-config-repo)` format