### PR TITLE
feat: ignore .github directory

### DIFF
--- a/incent-config/Dangerfile
+++ b/incent-config/Dangerfile
@@ -13,13 +13,14 @@ def ignore_list
     ..
     .circleci
     .git
+    .github
     .gitignore
+    README.md
     bin
+    cue.mod
     docs
     exceptions
-    README.md
     shared
-    cue.mod
   )
 end
 


### PR DESCRIPTION
We are migrating to GitHub Actions from CircleCI. Changes to the `.github` directory should not impact checks related to "more than one program-set".

AB#54862
